### PR TITLE
update targeted framework

### DIFF
--- a/eShopLegacyWebFormsSolution/src/eShopLegacyWebForms/packages.config
+++ b/eShopLegacyWebFormsSolution/src/eShopLegacyWebForms/packages.config
@@ -21,8 +21,8 @@
   <package id="Microsoft.AspNet.ScriptManager.WebForms" version="5.0.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.Web.Optimization.WebForms" version="1.1.3" targetFramework="net462" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.7" targetFramework="net47" />
-  <package id="Microsoft.Net.Compilers" version="2.1.0" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.7" targetFramework="net461" />
+  <package id="Microsoft.Net.Compilers" version="2.1.0" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.6.2" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net462" />


### PR DESCRIPTION
Mikkel,
I made this change because when I open the project, it won't compile. I got "Could not find a part of the path 'c:\t\ContainersSFLab\eShopLegacyWebFormsSolution\src\eShopLegacyWebForms\bin\roslyn\csc.exe'."

This change is the result of running update-package Microsoft.CodeDom.Providers.DotNetCompilerPlatform -r, from within the project. From the diff you can see that it updates the targetFramework for the DotNeCompilerPlatform from 4.61 to 4.7, and the targetFramework of Microsoft.Net.Compilers from 4.61 to 4.62
Since I will be pointing to this example from the MS docs, I thought I'd send this change on.